### PR TITLE
Ensure that `args` gets passed into `fun` by wrapping `fun`

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1200,7 +1200,9 @@ def boxcox_normmax(x, brack=None, method='pearsonr', optimizer=None):
         # `optimizer` is expected to return a `OptimizeResult` object, we here
         # get the solution to the optimization problem.
         def _optimizer(func, args):
-            return getattr(optimizer(func, args=args), 'x', None)
+            def func_wrapped(x):
+                return func(x, *args)
+            return getattr(optimizer(func_wrapped), 'x', None)
 
     def _pearsonr(x):
         osm_uniform = _calc_uniform_order_statistic_medians(len(x))

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -961,8 +961,8 @@ def boxcox(x, lmbda=None, alpha=None, optimizer=None):
         Must be between 0.0 and 1.0.
     optimizer : callable, optional
         If `lmbda` is None, `optimizer` is the scalar optimizer used to find
-        the value of `lmbda` that maximizes the log-likelihood function.
-        `optimizer` is a callable that accepts one argument:
+        the value of `lmbda` that minimizes the negative log-likelihood
+        function. `optimizer` is a callable that accepts one argument:
 
         fun : callable
             The objective function, which evaluates the negative
@@ -1103,8 +1103,8 @@ def boxcox_normmax(x, brack=None, method='pearsonr', optimizer=None):
             Useful to compare different methods.
     optimizer : callable, optional
         If `lmbda` is None, `optimizer` is the scalar optimizer used to find
-        the value of `lmbda` that maximizes the log-likelihood function.
-        `optimizer` is a callable that accepts one argument:
+        the value of `lmbda` that minimizes the negative log-likelihood
+        function. `optimizer` is a callable that accepts one argument:
 
         fun : callable
             The objective function, which evaluates the negative

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -962,14 +962,11 @@ def boxcox(x, lmbda=None, alpha=None, optimizer=None):
     optimizer : callable, optional
         If `lmbda` is None, `optimizer` is the scalar optimizer used to find
         the value of `lmbda` that maximizes the log-likelihood function.
-        `optimizer` is a callable that accepts two arguments:
+        `optimizer` is a callable that accepts one argument:
 
         fun : callable
             The objective function, which evaluates the negative
             log-likelihood function at a provided value of `lmbda`
-        args : tuple, optional
-            Additional arguments passed to the objective function as a
-            keyword argument
 
         and returns an object, such as an instance of
         `scipy.optimize.OptimizeResult`, which holds the optimal value of
@@ -1107,14 +1104,11 @@ def boxcox_normmax(x, brack=None, method='pearsonr', optimizer=None):
     optimizer : callable, optional
         If `lmbda` is None, `optimizer` is the scalar optimizer used to find
         the value of `lmbda` that maximizes the log-likelihood function.
-        `optimizer` is a callable that accepts two arguments:
+        `optimizer` is a callable that accepts one argument:
 
         fun : callable
             The objective function, which evaluates the negative
             log-likelihood function at a provided value of `lmbda`
-        args : tuple, optional
-            Additional arguments passed to the objective function as a
-            keyword argument
 
         and returns an object, such as an instance of
         `scipy.optimize.OptimizeResult`, which holds the optimal value of
@@ -1168,13 +1162,13 @@ def boxcox_normmax(x, brack=None, method='pearsonr', optimizer=None):
     want to use `scipy.optimize.minimize_scalar` with ``method='bounded'``,
     and we want to use tighter tolerances when optimizing the log-likelihood
     function. To do this, we define a function that accepts positional argument
-    `fun` and keyword argument `args` and passes them to
-    `scipy.optimize.minimize_scalar` along with the desired options:
+    `fun` and uses `scipy.optimize.minimize_scalar` to minimize `fun` subject
+    to the provided bounds and tolerances:
 
     >>> from scipy import optimize
     >>> options = {'xatol': 1e-12}  # absolute tolerance on `x`
-    >>> def optimizer(fun, args):
-    ...     return optimize.minimize_scalar(fun, bounds=(6, 7), args=args,
+    >>> def optimizer(fun):
+    ...     return optimize.minimize_scalar(fun, bounds=(6, 7),
     ...                                     method="bounded", options=options)
     >>> stats.boxcox_normmax(x, optimizer=optimizer)
     6.999...

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1567,8 +1567,8 @@ class TestBoxcox(object):
     @pytest.mark.parametrize("bounds", [(-1, 1), (1.1, 2), (-2, -1.1)])
     def test_bounded_optimizer_within_bounds(self, bounds):
         # Define custom optimizer with bounds.
-        def optimizer(fun, args):
-            return optimize.minimize_scalar(fun, bounds=bounds, args=args,
+        def optimizer(fun):
+            return optimize.minimize_scalar(fun, bounds=bounds,
                                             method="bounded")
 
         _, lmbda = stats.boxcox(_boxcox_data, lmbda=None, optimizer=optimizer)
@@ -1585,8 +1585,8 @@ class TestBoxcox(object):
         bounds = (lmbda + 0.1, lmbda + 1)
         options = {'xatol': 1e-12}
 
-        def optimizer(fun, args):
-            return optimize.minimize_scalar(fun, bounds=bounds, args=args,
+        def optimizer(fun):
+            return optimize.minimize_scalar(fun, bounds=bounds,
                                             method="bounded", options=options)
 
         # Check bounded solution. Lower bound should be active.
@@ -1606,7 +1606,7 @@ class TestBoxcox(object):
         # `OptimizeResult` object
 
         # Define test function that always returns 1
-        def optimizer(fun, args):
+        def optimizer(fun):
             return 1
 
         message = "`optimizer` must return an object containing the optimal..."
@@ -1638,8 +1638,8 @@ class TestBoxcoxNormmax(object):
     @pytest.mark.parametrize("bounds", [(-1, 1), (1.1, 2), (-2, -1.1)])
     def test_bounded_optimizer_within_bounds(self, method, bounds):
 
-        def optimizer(fun, args):
-            return optimize.minimize_scalar(fun, bounds=bounds, args=args,
+        def optimizer(fun):
+            return optimize.minimize_scalar(fun, bounds=bounds,
                                             method="bounded")
 
         maxlog = stats.boxcox_normmax(self.x, method=method,

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1647,6 +1647,28 @@ class TestBoxcoxNormmax(object):
         assert np.all(bounds[0] < maxlog)
         assert np.all(maxlog < bounds[1])
 
+    def test_user_defined_optimizer(self):
+        # tests an optimizer that is not based on scipy.optimize.minimize
+        lmbda = stats.boxcox_normmax(self.x)
+        lmbda_rounded = np.round(lmbda, 5)
+        lmbda_range = np.linspace(lmbda_rounded-0.01, lmbda_rounded+0.01, 1001)
+
+        class MyResult:
+            pass
+
+        def optimizer(fun):
+            # brute force minimum over the range
+            objs = []
+            for lmbda in lmbda_range:
+                objs.append(fun(lmbda))
+            res = MyResult()
+            res.x = lmbda_range[np.argmin(objs)]
+            return res
+
+        lmbda2 = stats.boxcox_normmax(self.x, optimizer=optimizer)
+        assert lmbda2 != lmbda                 # not identical
+        assert_allclose(lmbda2, lmbda, 1e-5)   # but as close as it should be
+
 
 class TestBoxcoxNormplot(object):
     def setup_method(self):


### PR DESCRIPTION
#### Reference issue
scipy/scipy#11911

#### What does this implement/fix?
`boxcox_normmax` assumed that `optimizer` would pass `args` into `fun` when calling it, but that wasn't specified in the documentation. We can solve that problem and provide a simpler interface if we ensure that `fun` gets `args` by wrapping it. This does that and adds a test with a user-defined optimizer that is not based on `scipy.optimize.minimize_scalar`.